### PR TITLE
Limit amount of trends to last 5

### DIFF
--- a/difido-reports-common/src/main/resources/il.co.topq.difido.view/controllers/sumBarChartController.js
+++ b/difido-reports-common/src/main/resources/il.co.topq.difido.view/controllers/sumBarChartController.js
@@ -37,6 +37,8 @@ function appendTestsToBar(tests, element) {
         }
 
     });
+
+    suites = suites.slice(-5);
     //The last scenario
     suites.push({"name": suiteName.slice(0,maxLengthOfSuiteName), "success": success, "error": error, "failure": failure, "warning": warning});
     


### PR DESCRIPTION
@itaia @aharonha I've limit the number of trends to the last 5. This is due to the fact that large amount of suites created loading issues and unable to read the trends due to their size.